### PR TITLE
Add Dockerfile.dev for Docker Compose fullstack

### DIFF
--- a/Recon/recon-client/Dockerfile.dev
+++ b/Recon/recon-client/Dockerfile.dev
@@ -1,0 +1,17 @@
+FROM node:18-alpine
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+
+EXPOSE 3000
+
+ENV BROWSER=none \
+    CHOKIDAR_USEPOLLING=true \
+    WDS_SOCKET_HOST=localhost \
+    NODE_OPTIONS=--openssl-legacy-provider
+
+CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- Adds `Dockerfile.dev` for running the CRA dev server inside Docker during local fullstack development.
- Configures Node 18, OpenSSL legacy provider, and file-watch polling for macOS Docker.

Used together with Recon repo `docker-compose.fullstack.yml` overlay.

## Test plan
- [x] Built via `docker compose -f docker-compose.yaml -f docker-compose.fullstack.yml up --build` (Recon repo)
- [x] Frontend served on http://localhost:3000
- [x] Login flow works against Docker backend on :4000 / :4001


Made with [Cursor](https://cursor.com)