### PR TITLE
Graceful profile picture fallback for local dev

### DIFF
--- a/Recon/recon-client/src/Routes/Home/Profile/ProfileForm.js
+++ b/Recon/recon-client/src/Routes/Home/Profile/ProfileForm.js
@@ -103,12 +103,11 @@ const ProfileForm = () => {
     const getProfilePictureURL = async () => {
       try {
         const resp = await axios(`/bucket/picture`)
-        //const encodedUrl = encodeURIComponent(resp.data);
-        const data = resp.data === "success"? "" : resp.data
-        setProfilePicURL({imageSrc: data, imageHash: Math.random()})
-        console.log(resp)
+        const data = resp.data === "success" ? "" : resp.data
+        setProfilePicURL({ imageSrc: data, imageHash: Math.random() })
       } catch (err) {
-        console.log(err)
+        // Local Docker / missing S3 credentials — keep default avatar without surfacing an error
+        setProfilePicURL((prev) => ({ imageSrc: "", imageHash: Math.random() }))
       }
     }
     getProfileDetails()


### PR DESCRIPTION
## Summary
- Silently keeps default avatar when `/bucket/picture` fails (common without S3 in Docker).

## Test plan
- [ ] Profile page loads without console errors when bucket endpoint returns 400
- [ ] Default silhouette still displays

Made with [Cursor](https://cursor.com)