### PR TITLE
Default dev API URLs to localhost when env vars are unset

### DIFF
--- a/Recon/recon-client/e2e/smoke-results/smoke-log.json
+++ b/Recon/recon-client/e2e/smoke-results/smoke-log.json
@@ -8,17 +8,17 @@
     {
       "step": "Contractor profile",
       "status": "pass",
-      "detail": "firstName=Bob"
+      "detail": "firstName=Bobbie"
     },
     {
       "step": "Contractor trainees (profile table)",
       "status": "pass",
-      "detail": "8 rows, sample: 0\t\ttrainee.1@yahoo.com\t\t"
+      "detail": "8 rows, first row: 0\tTrainee 1\ttrainee.1@yahoo.com\t—\t—"
     },
     {
       "step": "Report years page",
-      "status": "partial",
-      "detail": "Trainee selected but year dropdown empty. Options: No Months"
+      "status": "pass",
+      "detail": "Years loaded: 2026"
     },
     {
       "step": "School login",
@@ -46,19 +46,19 @@
       "method": "POST",
       "url": "http://localhost:4000/user/authenticate/contractor",
       "status": 200,
-      "body": "{\"token\":\"eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJjb250cmFjdG9yLjFAeWFob28uY29tIiwicm9sZSI6ImNvbnRyYWN0b3IiLCJleHAiOjE3Nzk1ODI2NDIsImlhdCI6MTc3OTU4MjU4Mn0.U3Qpx5-iD54E-aO-1q_j-17xiqime32wFhskfRO71JLP-p1-5e6VK"
+      "body": "{\"token\":\"eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJjb250cmFjdG9yLjFAeWFob28uY29tIiwicm9sZSI6ImNvbnRyYWN0b3IiLCJleHAiOjE3Nzk3Mzc0MDcsImlhdCI6MTc3OTczNzM0N30.7_kkE046-hmpH6CxDgOMmJc6fs1gLq2AqZO3Yxp8qOC80nVakEIAI"
     },
     {
       "method": "GET",
       "url": "http://localhost:4000/contractor/1",
       "status": 200,
-      "body": "{\"email\":\"contractor.1@yahoo.com\",\"firstName\":\"Bob\",\"lastName\":\"The Builder\",\"trainees\":[{\"traineeId\":1,\"email\":\"trainee.1@yahoo.com\",\"firstName\":\"Trainee\",\"lastName\":\"1\"},{\"traineeId\":3,\"email\":\"trai"
+      "body": "{\"email\":\"contractor.1@yahoo.com\",\"firstName\":\"Bobbie\",\"lastName\":\"The Builder\",\"trainees\":[{\"traineeId\":1,\"email\":\"trainee.1@yahoo.com\",\"firstName\":\"Trainee\",\"lastName\":\"1\"},{\"traineeId\":3,\"email\":\"t"
     },
     {
       "method": "GET",
       "url": "http://localhost:4000/contractor/1",
       "status": 200,
-      "body": "{\"email\":\"contractor.1@yahoo.com\",\"firstName\":\"Bob\",\"lastName\":\"The Builder\",\"trainees\":[{\"traineeId\":1,\"email\":\"trainee.1@yahoo.com\",\"firstName\":\"Trainee\",\"lastName\":\"1\"},{\"traineeId\":3,\"email\":\"trai"
+      "body": "{\"email\":\"contractor.1@yahoo.com\",\"firstName\":\"Bobbie\",\"lastName\":\"The Builder\",\"trainees\":[{\"traineeId\":1,\"email\":\"trainee.1@yahoo.com\",\"firstName\":\"Trainee\",\"lastName\":\"1\"},{\"traineeId\":3,\"email\":\"t"
     },
     {
       "method": "GET",
@@ -100,7 +100,7 @@
       "method": "POST",
       "url": "http://localhost:4000/user/authenticate/school",
       "status": 200,
-      "body": "{\"token\":\"eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJzY2hvb2wuMUB5YWhvby5jb20iLCJyb2xlIjoic2Nob29sIiwiZXhwIjoxNzc5NTgyNjU5LCJpYXQiOjE3Nzk1ODI1OTl9.BFqhq3tDqvgMqdYFBjE9jJMWCn5Cgs6PlRLNmdfpSHRrHNH8qF55jC13fRiu7eLa"
+      "body": "{\"token\":\"eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJzY2hvb2wuMUB5YWhvby5jb20iLCJyb2xlIjoic2Nob29sIiwiZXhwIjoxNzc5NzM3NDE3LCJpYXQiOjE3Nzk3MzczNTd9.gSmnGTm2XPlNx2OI2etRMuHxJw7jWrtcqDMaoKdtE4yPKgYS69WM5NO194gTuAkz"
     },
     {
       "method": "GET",
@@ -112,25 +112,25 @@
       "method": "GET",
       "url": "http://localhost:4000/school/1/students",
       "status": 200,
-      "body": "[{\"traineeId\":1,\"email\":\"trainee.1@yahoo.com\",\"firstName\":\"Trainee\",\"lastName\":\"1\"},{\"traineeId\":7,\"email\":\"trainee.7@yahoo.com\",\"firstName\":\"Trainee\",\"lastName\":\"7\"},{\"traineeId\":5,\"email\":\"trainee.5"
+      "body": "[{\"traineeId\":1,\"email\":\"trainee.1@yahoo.com\",\"firstName\":\"Trainee\",\"lastName\":\"1\"},{\"traineeId\":4,\"email\":\"trainee.4@yahoo.com\",\"firstName\":\"Trainee\",\"lastName\":\"4\"},{\"traineeId\":7,\"email\":\"trainee.7"
     },
     {
       "method": "GET",
       "url": "http://localhost:4000/school/1",
       "status": 200,
       "body": "{\"schoolId\":1,\"schoolName\":\"Aztec\",\"email\":\"school.1@yahoo.com\"}"
+    },
+    {
+      "method": "GET",
+      "url": "http://localhost:4000/school/1/students",
+      "status": 200,
+      "body": "[{\"traineeId\":1,\"email\":\"trainee.1@yahoo.com\",\"firstName\":\"Trainee\",\"lastName\":\"1\"},{\"traineeId\":4,\"email\":\"trainee.4@yahoo.com\",\"firstName\":\"Trainee\",\"lastName\":\"4\"},{\"traineeId\":7,\"email\":\"trainee.7"
     },
     {
       "method": "GET",
       "url": "http://localhost:4000/bucket/picture",
       "status": 400,
       "body": "failed"
-    },
-    {
-      "method": "GET",
-      "url": "http://localhost:4000/school/1/students",
-      "status": 200,
-      "body": "[{\"traineeId\":1,\"email\":\"trainee.1@yahoo.com\",\"firstName\":\"Trainee\",\"lastName\":\"1\"},{\"traineeId\":7,\"email\":\"trainee.7@yahoo.com\",\"firstName\":\"Trainee\",\"lastName\":\"7\"},{\"traineeId\":5,\"email\":\"trainee.5"
     },
     {
       "method": "GET",
@@ -142,19 +142,19 @@
       "method": "POST",
       "url": "http://localhost:4000/user/authenticate/trainee",
       "status": 200,
-      "body": "{\"token\":\"eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0cmFpbmVlLjFAeWFob28uY29tIiwicm9sZSI6InRyYWluZWUiLCJleHAiOjE3Nzk1ODI2NjQsImlhdCI6MTc3OTU4MjYwNH0.jXV-rmpJmATAphFxzjyDyPzngdlmWr-Hm3eRyI0skrxz5Sd2_1c2bb6bcz7sS"
+      "body": "{\"token\":\"eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0cmFpbmVlLjFAeWFob28uY29tIiwicm9sZSI6InRyYWluZWUiLCJleHAiOjE3Nzk3Mzc0MjIsImlhdCI6MTc3OTczNzM2Mn0.ns-RRUVl6S2-faOi9qNz0uLkDelT-H7_FMrQwyU93sP9pDW7hVuOm1H_aTsGw"
     },
     {
       "method": "GET",
       "url": "http://localhost:4000/trainee/1",
       "status": 200,
-      "body": "{\"email\":\"trainee.1@yahoo.com\",\"firstName\":\"Trainee\",\"lastName\":\"1\",\"supervisor\":{\"email\":\"contractor.1@yahoo.com\",\"firstName\":\"Bob\",\"lastName\":\"The Builder\"}}"
+      "body": "{\"email\":\"trainee.1@yahoo.com\",\"firstName\":\"Trainee\",\"lastName\":\"1\",\"supervisor\":{\"email\":\"contractor.1@yahoo.com\",\"firstName\":\"Bobbie\",\"lastName\":\"The Builder\"}}"
     },
     {
       "method": "GET",
       "url": "http://localhost:4000/trainee/1",
       "status": 200,
-      "body": "{\"email\":\"trainee.1@yahoo.com\",\"firstName\":\"Trainee\",\"lastName\":\"1\",\"supervisor\":{\"email\":\"contractor.1@yahoo.com\",\"firstName\":\"Bob\",\"lastName\":\"The Builder\"}}"
+      "body": "{\"email\":\"trainee.1@yahoo.com\",\"firstName\":\"Trainee\",\"lastName\":\"1\",\"supervisor\":{\"email\":\"contractor.1@yahoo.com\",\"firstName\":\"Bobbie\",\"lastName\":\"The Builder\"}}"
     },
     {
       "method": "GET",

--- a/Recon/recon-client/e2e/smoke-results/smoke-summary.txt
+++ b/Recon/recon-client/e2e/smoke-results/smoke-summary.txt
@@ -1,7 +1,7 @@
 PASS     Contractor login — Redirected to /home
-PASS     Contractor profile — firstName=Bob
-PASS     Contractor trainees (profile table) — 8 rows, sample: 0		trainee.1@yahoo.com		
-PARTIAL  Report years page — Trainee selected but year dropdown empty. Options: No Months
+PASS     Contractor profile — firstName=Bobbie
+PASS     Contractor trainees (profile table) — 8 rows, first row: 0	Trainee 1	trainee.1@yahoo.com	—	—
+PASS     Report years page — Years loaded: 2026
 PASS     School login — Redirected to /home
 PASS     School profile — schoolName="Aztec"
 PASS     Trainee login — Redirected to /home

--- a/Recon/recon-client/src/Utilities/URLs.js
+++ b/Recon/recon-client/src/Utilities/URLs.js
@@ -19,13 +19,27 @@ const trimTrailingSlashes = (u) =>
 const DEFAULT_API = "https://www.datareconreports.com";
 const DEFAULT_REPORTS = "https://www.datareconreports.com/reports";
 
+/** When REACT_APP_* is missing, dev builds default to local services (never silent prod). */
+const isDevelopment = process.env.NODE_ENV === "development";
+const DEV_DEFAULT_API = "http://localhost:4000";
+const DEV_DEFAULT_REPORTS = "http://localhost:4001";
+
 export const BASE_URL = trimTrailingSlashes(
-  process.env.REACT_APP_API_BASE_URL || DEFAULT_API
+  process.env.REACT_APP_API_BASE_URL ||
+    (isDevelopment ? DEV_DEFAULT_API : DEFAULT_API)
 );
 
 export const REPORTS_BASE_URL = trimTrailingSlashes(
-  process.env.REACT_APP_REPORTS_BASE_URL || DEFAULT_REPORTS
+  process.env.REACT_APP_REPORTS_BASE_URL ||
+    (isDevelopment ? DEV_DEFAULT_REPORTS : DEFAULT_REPORTS)
 );
+
+if (isDevelopment && !process.env.REACT_APP_REPORTS_BASE_URL) {
+  // eslint-disable-next-line no-console
+  console.warn(
+    "[URLs] REACT_APP_REPORTS_BASE_URL unset — using localhost:4001. Set REACT_APP_REPORTS_BASE_URL in .env.development(.local) to override."
+  );
+}
 
 /** @deprecated Use REPORTS_BASE_URL */
 export const LOCAL_REPORT_URL = REPORTS_BASE_URL;


### PR DESCRIPTION
## Summary
- In `NODE_ENV=development`, `BASE_URL` and `REPORTS_BASE_URL` default to `http://localhost:4000` and `http://localhost:4001` when `REACT_APP_*` are unset
- Production builds still default to `https://www.datareconreports.com` (no silent prod in local dev)
- Console warning when `REACT_APP_REPORTS_BASE_URL` is missing in dev
- Updated e2e smoke log/summary (8/8 pass against local stack)

## Test plan
- [ ] `npm start` without `.env.development.local` → network calls go to localhost:4000 / :4001
- [ ] Production build / deployed env still uses prod URLs when env vars unset
- [ ] Optional: `npm run e2e:smoke` (or project smoke script) against Docker fullstack


Made with [Cursor](https://cursor.com)